### PR TITLE
Reference should be functional quality, not deep quality.

### DIFF
--- a/quality.rst
+++ b/quality.rst
@@ -57,7 +57,7 @@ Think of characteristics such as:
 * *being beautiful*
 * *anticipating the user*
 
-Unlike the characteristics of deep quality, they cannot be checked or
+Unlike the characteristics of functional quality, they cannot be checked or
 measured, but they can still be clearly identified. When we encounter them,
 we usually (not always, because we need to be capable of it) recognise
 them.


### PR DESCRIPTION
The section explaining the differences between functional and deep quality, erroneously references deep quality when diving in on the contrast section. Instead, it should reference that *functional* quality can be checked and measured.

This change is to simply replace the phrase `deep quality` with `functional quality`.