### PR TITLE
Fix duplicate "independent" in the table in `quality.rst`

### DIFF
--- a/quality.rst
+++ b/quality.rst
@@ -118,7 +118,7 @@ deep quality we must *invent*.
    * - Functional quality
      - Deep quality
    * - independent characteristics
-     - independent characteristics
+     - interdependent characteristics
    * - objective
      - subjective
    * - measured against the world


### PR DESCRIPTION
Judging from the preceding explanation, the table should contrast independent vs. interdependent characteristics for functional vs. deep quality.

Instead, both columns list "independent characteristics", which seems like a mistake.