### PR TITLE
fix: typo in explanation.rst: 'discusive' -> 'discursive'

### DIFF
--- a/explanation.rst
+++ b/explanation.rst
@@ -3,7 +3,7 @@
 Explanation
 ===========
 
-..  rubric:: Explanation is a discusive treatment of a subject, that permits *reflection*. Explanation is
+..  rubric:: Explanation is a discursive treatment of a subject, that permits *reflection*. Explanation is
     **understanding-oriented**.
 
 ===========


### PR DESCRIPTION
I think you might have meant `discursive` here rather than `discusive`

I couldn't find [discusive](https://dictionary.cambridge.org/spellcheck/english/?q=discusive) in the dictionary

Thanks for this amazing project!