### PR TITLE
Correct typo in tutorials.rst

### DIFF
--- a/tutorials.rst
+++ b/tutorials.rst
@@ -206,7 +206,7 @@ A tutorial must inspire confidence. Confidence can only be built up layer by lay
 
     You are required to be present, but condemned to be absent. 
 
-A teacher who's there with the learner can rescue them when things go wrong. In a tutorial, you can't do that. Your tutorial ought to be so well constructed that things *can't* go wrong, that your tutorial works every user, every time.
+A teacher who's there with the learner can rescue them when things go wrong. In a tutorial, you can't do that. Your tutorial ought to be so well constructed that things *can't* go wrong, that your tutorial works for every user, every time.
 
 It's hard work to create a reliable experience, but that is what you must aspire to in creating a tutorial.
 


### PR DESCRIPTION
Corrects minor typo in the sentence `Your tutorial ought to be so well constructed that things *can't* go wrong, that your tutorial works every user, every time.` → `..., that your tutorial works *for* every user, every time`