### PR TITLE
Make reference-explanation.rst more self-consistent

### DIFF
--- a/reference-explanation.rst
+++ b/reference-explanation.rst
@@ -3,12 +3,12 @@
 The difference between reference and explanation
 ================================================
 
-Explanation and reference both belong to the *theory* half of the Diátaxis map - they don't contain
+Reference and explanation both belong to the *theory* half of the Diátaxis map - they don't contain
 steps to guide the reader, they contain theoretical knowledge.
 
-The difference between them is - just as in the difference between tutorials and how-to guides - the
-difference between the *acquisition* of skill and knowledge, and its *application*. In other words
-it's the distinction between *study* and *work*.
+The difference between them is - just as in the difference between tutorials and how-to guides - that
+reference is used in the *application* of skill and knowledge, whereas explanation is used for the
+*acquisition* of skill and knowledge. In other words, it's the distinction between *work* and *study*.
 
 
 A straightforward distinction, *mostly*


### PR DESCRIPTION
Update the introductory paragraph to, when comparing reference and explanation, to lead with reference, for consistency with the title of the page.

This was somewhat confusing to me when I was reading this page, because I assumed that it was relating reference to acquisition and explanation to application, and then I got further down the page and it was the other way around.