### PR TITLE
Fix 'feeling of doing' typo in tutorials.rst and a missing word in reference.rst

### DIFF
--- a/reference.rst
+++ b/reference.rst
@@ -74,7 +74,7 @@ It can be tempting to introduce instruction and explanation, simply because desc
 Adopt standard patterns
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-**Reference material is useful when it is consistent.** Standard patterns are what allow us to use reference material effectively. Your job is to place the material that your user needs know where they expect to find it, in a format that they are familiar with.
+**Reference material is useful when it is consistent.** Standard patterns are what allow us to use reference material effectively. Your job is to place the material that your user needs where they expect to find it, in a format that they are familiar with.
 
 There are many opportunities in writing to delight your readers with your extensive vocabulary and command of multiple styles, but reference material is definitely not one of them.
 

--- a/tutorials.rst
+++ b/tutorials.rst
@@ -152,7 +152,7 @@ Encourage and permit repetition
 
 Learners will return to and repeat an exercise that gives them success, for the pleasure they find in getting the expected result. Doing so reaffirms to them that they can do it, and that it works. 
 
-Repetition is a key to establishing the feeling to doing; being at home with that feeling is a foundational layer of learning.
+Repetition is a key to establishing the feeling of doing; being at home with that feeling is a foundational layer of learning.
 
 ..  sidebar::
 


### PR DESCRIPTION
I was reading through the docs and noticed a handful of small typos. This PR fixes the two that don't appear to be covered by other open PRs:

- `tutorials.rst`: "establishing the feeling to doing" → "feeling **of** doing" (matches the "feeling of doing" phrasing used elsewhere on the page)
- `reference.rst`: "the material that your user needs know where they expect to find it" was missing a word — dropped "know" so it reads "...the material that your user needs where they expect to find it"

I also spotted a few others while reading, but they already have open PRs, so I've left them out to avoid duplicating work:

- `compass.rst`: duplicated "think you" — already in #115
- `tutorials.rst`: doubled "know" in "If you know know in advance" — already in #115, #120, #134, #143, #160
- `quality.rst`: repeated "what" in "what exactly what we mean" — already in #121 and #139

A note on the `reference.rst` fix: #128 and #158 also address that sentence, but resolve it the other way ("...user needs **to know** where..."). I went with dropping "know", which reads more naturally to me, but happy to switch to the "to know" version if you prefer consistency with those PRs.

All cosmetic, no content changes.
